### PR TITLE
[lint] Fix irrelevant errors.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ block_comment_end = */
 [{bw-dev,fr-dev,LICENSE}]
 max_line_length = off
 
-[*.{csv,json,html,md,po,py,svg,tsv}]
+[*.{csv,json,html,md,mo,po,py,svg,tsv}]
 max_line_length = off
 
 [*.{md,markdown}]
@@ -30,7 +30,11 @@ trim_trailing_whitespace = false
 indent_size = 2
 max_line_length = off
 
-[{package.json,yarn.lock}]
+[{package.json,*.lock}]
 indent_size = unset
 indent_style = unset
 max_line_length = unset
+
+[*.mo]
+insert_final_newline = unset
+


### PR DESCRIPTION
Hello!

I have set up the editorconfig linter that’s triggering [some irrelevant errors on your PR](https://github.com/bookwyrm-social/bookwyrm/pull/860/checks?check_run_id=2260841186#step:4:13), so here’s a fix that you can merge to not be bothered by those. :)